### PR TITLE
Made setup check for openMP more robust.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,16 @@ def checkOpenmpSupport():
     os.chdir(tmpdir)
 
     filename = r'test.c'
-    with open(filename, 'w') as file:
-        file.write(ompTest)
-    with open(os.devnull, 'w') as fnull:
-        result = subprocess.call(['cc', '-fopenmp', filename],
-                                 stdout=fnull, stderr=fnull)
-
+    try:
+        with open(filename, 'w') as file:
+            file.write(ompTest)
+        with open(os.devnull, 'w') as fnull:
+            result = subprocess.call(['cc', '-fopenmp', filename],
+                                     stdout=fnull, stderr=fnull)
+    except:
+        print("Failed to test for OpenMP support. Assuming unavailability");
+        result = -1;
+    
     os.chdir(curdir)
     shutil.rmtree(tmpdir) 
     if result == 0:


### PR DESCRIPTION
setup's check for openMP would crash on my machine on various files-not-founds. Thought it would be a good idea to just have it fall back more gracefully.