### PR TITLE
Implemention of skipping zero elements in Contact Matrix 

### DIFF
--- a/pyross/deterministic.pxd
+++ b/pyross/deterministic.pxd
@@ -263,7 +263,7 @@ cdef class Spp(CommonMethods):
     """
 
     cdef:
-        readonly int constant_CM,	
+        readonly int constant_CM
         readonly np.ndarray constant_terms, linear_terms, infection_terms, finres_terms, resource_list
         readonly np.ndarray parameters
         readonly np.ndarray parameters_length

--- a/pyross/deterministic.pxd
+++ b/pyross/deterministic.pxd
@@ -263,6 +263,7 @@ cdef class Spp(CommonMethods):
     """
 
     cdef:
+        readonly int constant_CM,	
         readonly np.ndarray constant_terms, linear_terms, infection_terms, finres_terms, resource_list
         readonly np.ndarray parameters
         readonly np.ndarray parameters_length
@@ -272,6 +273,7 @@ cdef class Spp(CommonMethods):
         readonly np.ndarray _lambdas
         readonly object time_dep_param_mapping
         readonly np.ndarray finres_pop
+        readonly np.ndarray nonzero_index_n
 
     cpdef rhs(self, rp, tt)
     

--- a/pyross/deterministic.pyx
+++ b/pyross/deterministic.pyx
@@ -3,7 +3,6 @@ cimport numpy as np
 cimport cython
 import pyross.utils
 import warnings
-from cython.parallel import prange
 
 DTYPE   = np.float
 from libc.stdlib cimport malloc, free
@@ -2752,7 +2751,7 @@ cdef class Spp(CommonMethods):
             Ni = xt_arr[(nClass-1)*M:] # update Ni
 
         if self.constant_CM == 1:
-            for m in prange(M, nogil=True):
+            for m in range(M):
                 for i in range(infection_terms.shape[0]):
                     infective_index = infection_terms[i, 1]
                     lambdas[i, m] = 0
@@ -2762,7 +2761,7 @@ cdef class Spp(CommonMethods):
                         if Ni[nn]>0:
                             lambdas[i, m] += CM[m,nn]*xt[index]/Ni[nn]
         else:
-            for m in prange(M, nogil=True):
+            for m in range(M):
                 for i in range(infection_terms.shape[0]):
                     infective_index = infection_terms[i, 1]
                     lambdas[i, m] = 0


### PR DESCRIPTION
To improve computation rate using big contact matrix, I implement skipping zero elements in the contact matrix.
Additionally, the loop of the lambdas calculation is parallelized and I defined the variable **infective_index** which used in the lambdas calculation.
This feature can be turned on or off as **constatnt_CM** which is an argument of **pyross.deterministic.Spp**.
If **constatnt_CM**=0, this skipping is turned off. The default value is  **constatnt_CM**=0.

For London simulation including around 1000 node, the previous implementation takes 10 minutes.
The present implementation takes 100 seconds without the skipping of zero elements.
When the skipping of zero elements is turned on, the present implementation takes 20 seconds.

However, the implementation of PyrossGeo takes 2 seconds for the same simulation with using non-local interaction model.